### PR TITLE
Support insert_final_newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * `indent_style`
 * `indent_size`
+* `insert_final_newline`
 
 ## On the backlog
 

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -1,6 +1,7 @@
 import * as editorconfig from 'editorconfig';
 import * as fs from 'fs';
-import {commands, window, workspace, ExtensionContext, TextEditorOptions, TextEditor, TextDocument, Disposable} from 'vscode';
+import {commands, window, workspace, ExtensionContext, TextEditorOptions,
+    TextEditor, TextEdit, TextDocument, Disposable, Position} from 'vscode';
 
 export function activate(ctx: ExtensionContext): void {
 
@@ -41,6 +42,7 @@ class DocumentWatcher implements IEditorConfigProvider {
                 // Saved an .editorconfig file => rebuild map entirely
                 this._rebuildConfigMap();
             }
+            applyOnSaveTransformations(savedDocument, this);
         }));
 
         // dispose event subscriptons upon disposal
@@ -106,6 +108,58 @@ function applyEditorConfigToTextEditor(textEditor:TextEditor, provider:IEditorCo
     window.setStatusBarMessage('EditorConfig: ' + (newOptions.insertSpaces ? "Spaces:" : "Tabs:") + ' ' + newOptions.tabSize, 1500);
 
     textEditor.options = newOptions;
+}
+
+function applyOnSaveTransformations(
+    textDocument:TextDocument,
+    provider:IEditorConfigProvider): void {
+
+    let editorconfig = provider.getSettingsForDocument(textDocument);
+
+    if (!editorconfig) {
+        // no configuration found for this file
+        return;
+    }
+
+    insertFinalNewlineTransform(editorconfig, textDocument);
+}
+
+function insertFinalNewlineTransform(editorconfig: editorconfig.knownProps, textDocument: TextDocument): void {
+    if (editorconfig.insert_final_newline && textDocument.lineCount > 0) {
+        let lastLine = textDocument.lineAt(textDocument.lineCount - 1);
+        let lastLineLength = lastLine.text.length;
+        if (lastLineLength < 1) {
+            return;
+        }
+        let editor = findEditor(textDocument);
+        if (!editor) {
+            return;
+        }
+        editor.edit(edit => {
+            let pos = new Position(lastLine.lineNumber, lastLineLength);
+            edit.insert(pos, newline(editorconfig));
+            textDocument.save();
+        });
+    }
+}
+
+function newline(editorconfig: editorconfig.knownProps): string {
+    if (editorconfig.end_of_line === 'cr') {
+        return '\r';
+    } else if (editorconfig.end_of_line == 'crlf') {
+        return '\r\n';
+    }
+    return '\n';
+}
+
+function findEditor(textDocument: TextDocument): TextEditor {
+    for (let editor of window.visibleTextEditors) {
+        if (editor.document === textDocument) {
+            return editor;
+        }
+    }
+
+    return null;
 }
 
 /**

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -124,7 +124,10 @@ function applyOnSaveTransformations(
     insertFinalNewlineTransform(editorconfig, textDocument);
 }
 
-function insertFinalNewlineTransform(editorconfig: editorconfig.knownProps, textDocument: TextDocument): void {
+function insertFinalNewlineTransform(
+    editorconfig: editorconfig.knownProps,
+    textDocument: TextDocument): void {
+
     if (editorconfig.insert_final_newline && textDocument.lineCount > 0) {
         let lastLine = textDocument.lineAt(textDocument.lineCount - 1);
         let lastLineLength = lastLine.text.length;
@@ -137,9 +140,8 @@ function insertFinalNewlineTransform(editorconfig: editorconfig.knownProps, text
         }
         editor.edit(edit => {
             let pos = new Position(lastLine.lineNumber, lastLineLength);
-            edit.insert(pos, newline(editorconfig));
-            textDocument.save();
-        });
+            return edit.insert(pos, newline(editorconfig));
+        }).then(() => textDocument.save());
     }
 }
 


### PR DESCRIPTION
This commit adds a function applyOnSaveTransformations that is intended to
run the required checks whenever a document is saved. For now it runs the
other new feature of this commit; the insertFinalNewlineTransform, which
checks whether the .editorconfig has 'insert_final_newline: true'. If
insert_final_newline is true, we add a newline if it doesn't already exist.
