### PR TITLE
Trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ ext install vscodeEditorConfig
 * `indent_size`
 * `tab_width`
 * `insert_final_newline`
+* `trim_trailing_whitespace`
 
 ## On the backlog
 
 * `charset`
 * `end_of_line`
-* `trim_trailing_whitespace`
 

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -1,7 +1,7 @@
 import * as editorconfig from 'editorconfig';
 import * as fs from 'fs';
 import {commands, window, workspace, ExtensionContext, TextEditorOptions,
-    TextEditor, TextEdit, TextDocument, Disposable, Position} from 'vscode';
+    TextEditor, TextEdit, TextDocument, Disposable, Position, Range} from 'vscode';
 
 export function activate(ctx: ExtensionContext): void {
 
@@ -131,9 +131,10 @@ function applyOnSaveTransformations(
     let editor = findEditor(textDocument);
     if (!editor) {
         return;
-}
+    }
 
     insertFinalNewlineTransform(editorconfig, editor, textDocument);
+    trimTrailingWhitespaceTransform(editorconfig, editor, textDocument);
 }
 
 function insertFinalNewlineTransform(
@@ -152,6 +153,37 @@ function insertFinalNewlineTransform(
             return edit.insert(pos, newline(editorconfig));
         }).then(() => textDocument.save());
     }
+}
+
+function trimTrailingWhitespaceTransform(
+    editorconfig: editorconfig.knownProps,
+    editor: TextEditor,
+    textDocument: TextDocument): void {
+
+    let editorAlreadyTrimsWhitespace = workspace.getConfiguration('files')['trimTrailingWhitespace'];
+    let nothingToDo = !editorconfig.trim_trailing_whitespace || editorAlreadyTrimsWhitespace;
+
+    if (nothingToDo) {
+        return;
+    }
+
+    let trailingWhitespaceRegex = new RegExp('/(\s)$/');
+    for(let i = 0; i < textDocument.lineCount; i++) {
+        var line = textDocument.lineAt(i);
+        var trimmedLine = trimTrailingWhitespace(line.text);
+        if (trimmedLine !== line.text) {
+            editor.edit(edit => {
+                let whitespaceBegin = new Position(line.lineNumber, trimmedLine.length);
+                let whitespaceEnd = new Position(line.lineNumber, line.text.length);
+                let whitespace = new Range(whitespaceBegin, whitespaceEnd);
+                edit.delete(whitespace);
+            }).then(() => textDocument.save());
+        }
+    }
+}
+
+function trimTrailingWhitespace(input: string): string {
+    return input.replace(/[\s\uFEFF\xA0]+$/g, '');
 }
 
 function newline(editorconfig: editorconfig.knownProps): string {

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -167,7 +167,6 @@ function trimTrailingWhitespaceTransform(
         return;
     }
 
-    let trailingWhitespaceRegex = new RegExp('/(\s)$/');
     for(let i = 0; i < textDocument.lineCount; i++) {
         var line = textDocument.lineAt(i);
         var trimmedLine = trimTrailingWhitespace(line.text);

--- a/src/editorConfigMain.ts
+++ b/src/editorConfigMain.ts
@@ -128,21 +128,23 @@ function applyOnSaveTransformations(
         return;
     }
 
-    insertFinalNewlineTransform(editorconfig, textDocument);
+    let editor = findEditor(textDocument);
+    if (!editor) {
+        return;
+}
+
+    insertFinalNewlineTransform(editorconfig, editor, textDocument);
 }
 
 function insertFinalNewlineTransform(
     editorconfig: editorconfig.knownProps,
+    editor: TextEditor,
     textDocument: TextDocument): void {
 
     if (editorconfig.insert_final_newline && textDocument.lineCount > 0) {
         let lastLine = textDocument.lineAt(textDocument.lineCount - 1);
         let lastLineLength = lastLine.text.length;
         if (lastLineLength < 1) {
-            return;
-        }
-        let editor = findEditor(textDocument);
-        if (!editor) {
             return;
         }
         editor.edit(edit => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es5",
 		"outDir": "out",
 		"noLib": true,
 		"sourceMap": true


### PR DESCRIPTION
Fixes #6 

This PR implements trimming of trailing whitespace. It does not override the user/workspace setting of `files.trimTrailingWhitespace`, meaning that if the VS Code setting is `true`, then this code won't do anything. (I don't know of any way to override the VS Code setting anyway)
